### PR TITLE
ci: pin actions/checkout and shivammathur/setup-php action to specific commit

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -15,12 +15,12 @@ jobs:
 
     steps:
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@ec406be512d7077f68eed36e63f4d91bc006edc4
         with:
           php-version: '8.4'
 
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
 
       - name: Install base dependencies (without scraper)
         run: |

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -22,13 +22,13 @@ jobs:
           - '8.4'
     steps:
       - name: Setup PHP ${{ matrix.php-version }}
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@ec406be512d7077f68eed36e63f4d91bc006edc4
         with:
           php-version: ${{ matrix.php-version }}
           extensions: mbstring, xml
 
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
 
       - name: Install Dependencies
         run: composer install --prefer-dist --no-interaction --no-progress --dev


### PR DESCRIPTION
セキュリティ強化のために actions/checkout と shivammathur/setup-php のバージョンを特定のコミット SHA に固定しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- チャores
  - 定期実行および静的解析のワークフローで依存アクションを固定化し、ビルドの再現性を向上。
  - 外部アクションのバージョン揺れを排除し、予期せぬ変更によるCI不安定化を抑制。
  - 実行手順や挙動は従来どおりで、ユーザー向け機能への影響はなし。
  - セキュリティと信頼性を強化し、監査性と保守性を改善。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->