### PR TITLE
chore: add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "deps"
+      include: "scope"


### PR DESCRIPTION
GitHub Actions の SHA 固定を自動更新するために dependabot.yml を追加しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Dependabot を導入し、GitHub Actions の依存関係を週次で自動更新する設定を追加。
  * コミットメッセージに「deps」プレフィックスとスコープを付与し、更新履歴の可読性を向上。
  * アプリの機能やUIへの影響はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->